### PR TITLE
Fix getAvailablePathForAttachments depending on the file data

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -851,11 +851,18 @@ export default class ImportAttachments extends Plugin {
         if(md_file) {attachmentName = attachmentName.replace(/\$\{notename\}/g, md_file.filename);}
 
         if(namePattern.includes('${md5}')) {
-            let hash = ''
+            let hash: string;
             try {
                 hash = await Utils.hashFile(originalFilePath);
             } catch (err: unknown) {
-                console.error('Error hashing the file:', err);
+                // The content is not (yet) on disk. This happens when we are called through the
+                // patched `Vault.getAvailablePathForAttachments`, i.e. when Obsidian or another
+                // plugin asks for a destination path *before* creating the file: there are no
+                // bytes to hash anywhere at that moment. Fall back to a uuid, which preserves the
+                // uniqueness that ${md5} is chosen for; leaving the token empty would produce
+                // names such as `.png` when the pattern is just `${md5}`.
+                hash = Utils.uuidv4();
+                console.warn(`Import Attachments+: could not compute \${md5} for '${originalFilePath}'; using a uuid instead.`, err);
             }
             attachmentName = attachmentName.replace(/\$\{md5\}/g, hash);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -836,7 +836,7 @@ export default class ImportAttachments extends Plugin {
         return attachmentsFolderPath;           
     }
 
-    async createAttachmentName(originalFilePath:string, data: File | ArrayBuffer, md_file: ParsedPath | undefined): Promise<string> {
+    async createAttachmentName(originalFilePath:string, md_file: ParsedPath | undefined): Promise<string> {
 
         const originalFilePath_parsed = Utils.parseFilePath(originalFilePath);
         const namePattern = this.settings.attachmentName;
@@ -1191,7 +1191,7 @@ export default class ImportAttachments extends Plugin {
 
 		const tasks = filesToImport.map(async (fileToImport): Promise<string | null> => {
 			const originalFilePath = fileToImport.path;
-			let destFilePath = await this.createAttachmentName(originalFilePath,fileToImport,md_file_parsed);
+			let destFilePath = await this.createAttachmentName(originalFilePath, md_file_parsed);
 
 			// Check if file already exists in the vault
 			const existingFile = await Utils.doesFileExist(this.app.vault,destFilePath);

--- a/src/patchImportFunctions.ts
+++ b/src/patchImportFunctions.ts
@@ -8,7 +8,6 @@ import { parseFilePath } from 'utils';
 // Save a reference to the original method for the monkey patch
 let originalGetAvailablePathForAttachments: ((fileName: string, extension: string, currentFile: TFile | null) => Promise<string>) | null = null;
 let originalSaveAttachment: ((fileName: string, fileExtension: string, fileData: ArrayBuffer) => Promise<TFile>) | null = null;
-let data: ArrayBuffer | null = null;
 
 function unpatchImportFunctions() {
 	if (originalGetAvailablePathForAttachments) {
@@ -33,12 +32,10 @@ function patchImportFunctions(plugin: ImportAttachments) {
 		if (!originalGetAvailablePathForAttachments) {
 			throw new Error('Could not execute the original getAvailablePathForAttachments function.');
 		}
-
-		if(!data) {throw new Error('The variable data is unexpectedly null.')}
 		
 		const currentFile_parsed = currentFile ? parseFilePath(currentFile.path) : undefined;
 		
-		return await plugin.createAttachmentName(fileName + '.' + extension,data,currentFile_parsed);
+		return await plugin.createAttachmentName(fileName + '.' + extension, currentFile_parsed);
 	};
 
 	if (!originalSaveAttachment) {
@@ -51,10 +48,7 @@ function patchImportFunctions(plugin: ImportAttachments) {
 			throw new Error('Could not execute the original saveAttachment function.');
 		}
 
-		// Save `data` in the module variable. This allows getAvailablePathForAttachments, which is called from `originalsaveAttachment`, to use `data`
-		data = fileData;
 		const newAttachmentFile = await originalSaveAttachment.apply(this, [fileName, fileExtension, fileData]);
-		data = null;
 
 		/*
 		// The current active file in the workspace

--- a/src/patchImportFunctions.ts
+++ b/src/patchImportFunctions.ts
@@ -3,7 +3,7 @@
 import { App, Vault, TFile } from 'obsidian';
 import ImportAttachments from 'main';
 
-import { parseFilePath } from 'utils';
+import { parseFilePath, doesFileExist, findNewFilename } from 'utils';
 
 // Save a reference to the original method for the monkey patch
 let originalGetAvailablePathForAttachments: ((fileName: string, extension: string, currentFile: TFile | null) => Promise<string>) | null = null;
@@ -35,7 +35,18 @@ function patchImportFunctions(plugin: ImportAttachments) {
 		
 		const currentFile_parsed = currentFile ? parseFilePath(currentFile.path) : undefined;
 		
-		return await plugin.createAttachmentName(fileName + '.' + extension, currentFile_parsed);
+		const attachmentPath = await plugin.createAttachmentName(fileName + '.' + extension, currentFile_parsed);
+
+		// Obsidian's own implementation ends with `getAvailablePath`, so it never returns a path
+		// that is already taken. Callers (`saveAttachment`, but also third-party plugins reaching us
+		// through `FileManager.getAvailablePathForAttachment`) create a file at the returned path
+		// without checking, so we have to honour the same contract or we silently overwrite
+		// attachments whenever the name pattern is not unique (e.g. `${original}` or `${notename}`).
+		if (doesFileExist(plugin.app.vault, attachmentPath)) {
+			return findNewFilename(plugin.app.vault, attachmentPath);
+		}
+
+		return attachmentPath;
 	};
 
 	if (!originalSaveAttachment) {


### PR DESCRIPTION
A potential fix for #18.

It seems to work and it *seems* this is all dead code but I don't fully understand why it was in there in the first place.

## Summary by Sourcery

Ensure attachment path generation no longer depends on transient file data and preserves Obsidian’s uniqueness guarantees.

Bug Fixes:
- Prevent attachment name collisions by checking for existing files and generating a new unique filename when needed.
- Handle cases where attachment content is not yet on disk by falling back from MD5 hashing to a UUID-based token.

Enhancements:
- Simplify attachment naming API to no longer require file data and remove now-unnecessary shared state between patched functions.